### PR TITLE
Generate a character sheet PDF using LaTeX.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__/
 */*/index.html
 .idea/
+*.pdf
+*.tex

--- a/ddddd/sheet/README.md
+++ b/ddddd/sheet/README.md
@@ -3,3 +3,5 @@
 This generator will generate a usable character sheet, based on the player character (PC) model, in PDF format.
 
 The generator uses PyLatex. In order for the character sheet generator to work, you must install `latexmk` on your machine separately. In the future, a script may be written to automate this process.
+
+Reference: https://github.com/JelteF/PyLaTeX

--- a/ddddd/sheet/README.md
+++ b/ddddd/sheet/README.md
@@ -1,0 +1,5 @@
+# Character Sheet Generator
+
+This generator will generate a usable character sheet, based on the player character (PC) model, in PDF format.
+
+The generator uses PyLatex. In order for the character sheet generator to work, you must install `latexmk` on your machine separately. In the future, a script may be written to automate this process.

--- a/ddddd/sheet/sheet_generator.py
+++ b/ddddd/sheet/sheet_generator.py
@@ -1,0 +1,60 @@
+from pylatex import Document, Section, Subsection, Command
+from pylatex.utils import italic, NoEscape
+
+from ddddd.pc_playground import get_available_characters
+
+
+def generate_character_sheet(pc):
+    print('Hello world!')
+
+
+def fill_document(doc):
+    """Add a section, a subsection and some text to the document.
+
+    :param doc: the document
+    :type doc: :class:`pylatex.document.Document` instance
+    """
+    with doc.create(Section('A section')):
+        doc.append('Some regular text and some ')
+        doc.append(italic('italic text. '))
+
+        with doc.create(Subsection('A subsection')):
+            doc.append('Also some crazy characters: $&#{}')
+
+
+def create_document():
+    # Basic document
+    doc = Document('basic')
+    fill_document(doc)
+
+    doc.generate_pdf(clean_tex=False)
+    doc.generate_tex()
+
+    # Document with `\maketitle` command activated
+    doc = Document()
+
+    doc.preamble.append(Command('title', 'Awesome Title'))
+    doc.preamble.append(Command('author', 'Anonymous author'))
+    doc.preamble.append(Command('date', NoEscape(r'\today')))
+    doc.append(NoEscape(r'\maketitle'))
+
+    fill_document(doc)
+
+    doc.generate_pdf('basic_maketitle', clean_tex=False)
+
+    # Add stuff to the document
+    with doc.create(Section('A second section')):
+        doc.append('Some text.')
+
+    doc.generate_pdf('basic_maketitle2', clean_tex=False)
+    tex = doc.dumps()  # The document as string in LaTeX syntax
+
+
+def main():
+    fethri = get_available_characters()['fethri']['create']()
+    generate_character_sheet(fethri)
+    create_document()
+
+
+if __name__ == '__main__':
+    main()

--- a/ddddd/sheet/sheet_generator.py
+++ b/ddddd/sheet/sheet_generator.py
@@ -1,59 +1,99 @@
-from pylatex import Document, Section, Subsection, Command
-from pylatex.utils import italic, NoEscape
+from pylatex import Document, Section, Subsection, Command, LineBreak, LongTable
+from pylatex.utils import italic, NoEscape, bold
 
+from ddddd.entity import base
 from ddddd.pc_playground import get_available_characters
 
 
+def generate_file_friendly_name(name):
+    return name.lower().replace(' ', '_')
+
+
 def generate_character_sheet(pc):
-    print('Hello world!')
+    doc = Document(generate_file_friendly_name(pc.name))
 
+    doc.preamble.append(Command('title', pc.name))
+    doc.preamble.append(Command('author', 'IceShirok'))
+    doc.append(NoEscape(r'\maketitle'))
 
-def fill_document(doc):
-    """Add a section, a subsection and some text to the document.
+    with doc.create(Section('Basics', numbering=False)):
+        doc.append(bold('Class & Level'))
+        doc.append(' {} {}'.format(pc.vocation_name, pc.level))
+        doc.append(LineBreak())
 
-    :param doc: the document
-    :type doc: :class:`pylatex.document.Document` instance
-    """
-    with doc.create(Section('A section')):
-        doc.append('Some regular text and some ')
-        doc.append(italic('italic text. '))
+        doc.append(bold('Background'))
+        doc.append(' {}'.format(pc.background_name))
+        doc.append(LineBreak())
 
-        with doc.create(Subsection('A subsection')):
-            doc.append('Also some crazy characters: $&#{}')
+        doc.append(bold('Race'))
+        doc.append(' {} ({})'.format(pc.base_race_name, pc.race_name))
+        doc.append(LineBreak())
 
+    with doc.create(Section('Basic Combat Stuff', numbering=False)):
+        doc.append(bold('Armor Class'))
+        armor_class_source = pc.worn_items.armor.name if pc.worn_items.armor else 'dodgy stuff'
+        doc.append(' {} ({})'.format(pc.armor_class, armor_class_source))
+        doc.append(LineBreak())
 
-def create_document():
-    # Basic document
-    doc = Document('basic')
-    fill_document(doc)
+        doc.append(bold('Initiative'))
+        doc.append(' {}'.format(pc.initiative))
+        doc.append(LineBreak())
+
+        doc.append(bold('Speed'))
+        doc.append(' {} ft'.format(pc.speed))
+        doc.append(LineBreak())
+
+    with doc.create(Section('Ability Scores', numbering=False)):
+        doc.append(bold('Proficiency Bonus'))
+        doc.append(' {}'.format(base.prettify_modifier(pc.proficiency_bonus)))
+        doc.append(LineBreak())
+
+        with doc.create(LongTable("l l l")) as data_table:
+            data_table.add_hline()
+            data_table.add_row(['Ability', 'Score', 'Modifier'])
+            data_table.add_hline()
+            data_table.end_table_header()
+            for ability in pc.ability_scores.keys():
+                ability_row = [
+                    ability,
+                    pc.ability_scores[ability].score,
+                    base.prettify_modifier(pc.ability_scores[ability].modifier),
+                ]
+                data_table.add_row(ability_row)
+
+        for ability in pc.ability_scores.keys():
+            with doc.create(Subsection('Ability Proficiencies: {}'.format(ability), numbering=False)):
+                with doc.create(LongTable("l l l")) as data_table:
+                    save_proficiency = 'proficient' if pc.saving_throws[ability]['is_proficient'] else '-'
+                    saving_throw_row = [
+                        'Saving Throw',
+                        base.prettify_modifier(pc.saving_throws[ability]['modifier']),
+                        save_proficiency,
+                    ]
+                    data_table.add_row(saving_throw_row)
+                    if ability in pc.skills_by_ability:
+                        for skill in pc.skills_by_ability[ability]:
+                            skill_details = pc.skills_by_ability[ability][skill]
+                            modifier = skill_details['modifier']
+                            skill_proficiency = '-'
+                            if skill_details['is_proficient']:
+                                skill_proficiency = 'skilled'
+                            if skill_details['expertise']:
+                                skill_proficiency = 'expert'
+                            skill_row = [
+                                skill,
+                                base.prettify_modifier(modifier),
+                                skill_proficiency,
+                            ]
+                            data_table.add_row(skill_row)
 
     doc.generate_pdf(clean_tex=False)
     doc.generate_tex()
-
-    # Document with `\maketitle` command activated
-    doc = Document()
-
-    doc.preamble.append(Command('title', 'Awesome Title'))
-    doc.preamble.append(Command('author', 'Anonymous author'))
-    doc.preamble.append(Command('date', NoEscape(r'\today')))
-    doc.append(NoEscape(r'\maketitle'))
-
-    fill_document(doc)
-
-    doc.generate_pdf('basic_maketitle', clean_tex=False)
-
-    # Add stuff to the document
-    with doc.create(Section('A second section')):
-        doc.append('Some text.')
-
-    doc.generate_pdf('basic_maketitle2', clean_tex=False)
-    tex = doc.dumps()  # The document as string in LaTeX syntax
 
 
 def main():
     fethri = get_available_characters()['fethri']['create']()
     generate_character_sheet(fethri)
-    create_document()
 
 
 if __name__ == '__main__':

--- a/ddddd/sheet/sheet_generator.py
+++ b/ddddd/sheet/sheet_generator.py
@@ -1,4 +1,4 @@
-from pylatex import Document, Section, Subsection, Command, LineBreak, LongTable, Itemize
+from pylatex import Document, Section, Subsection, Command, LineBreak, LongTable, Itemize, LargeText
 from pylatex.utils import italic, NoEscape, bold
 
 from ddddd.entity import base
@@ -129,13 +129,45 @@ def generate_character_sheet(pc):
                         cantrip_details = pc.calculate_damage_cantrips()[cantrip_name]
 
                         cantrip_row = [
-                            cantrip_details.name,
+                            cantrip_name,
                             cantrip_details['attack_bonus'],
                             cantrip_details['damage'],
                         ]
                         data_table.add_row(cantrip_row)
 
-        # TODO add section for spellcasting, too lazy right now
+        with doc.create(Subsection('Spellcasting', numbering=False)):
+            doc.append(bold('Spellcasting Ability'))
+            doc.append(' {}'.format(pc.spellcasting.spellcasting_ability))
+            doc.append(LineBreak())
+
+            doc.append(bold('Spell Save DC'))
+            doc.append(' {}'.format(pc.spell_save_dc))
+            doc.append(LineBreak())
+
+            doc.append(bold('Spell Attack Bonus'))
+            doc.append(' {}'.format(base.prettify_modifier(pc.spell_attack_bonus)))
+            doc.append(LineBreak())
+
+            def generate_spell_card(spell, doc):
+                doc.append(LargeText(spell.name))
+                with doc.create(LongTable("l l")) as data_table:
+                    data_table.add_row(['Name', spell.name])
+                    data_table.add_row(['Type', '{}-level {}'.format(spell.level, spell.magic_school)])
+                    data_table.add_row(['Casting time', spell.casting_time])
+                    data_table.add_row(['Range', spell.spell_range])
+                    data_table.add_row(['Components', ', '.join(spell.components)])
+                    data_table.add_row(['Duration', spell.duration])
+                    data_table.add_row(['Description', spell.description])
+
+            if pc.spellcasting and pc.cantrips:
+                with doc.create(Subsection('Cantrips', numbering=False)):
+                    for cantrip in pc.cantrips:
+                        generate_spell_card(cantrip, doc)
+
+            for spell_type in pc.casting_spells.keys():
+                with doc.create(Subsection(spell_type, numbering=False)):
+                    for spell in pc.casting_spells[spell_type]:
+                        generate_spell_card(spell, doc)
 
     with doc.create(Section('Proficiencies', numbering=False)):
         with doc.create(Subsection('Languages', numbering=False)):
@@ -198,8 +230,8 @@ def generate_character_sheet(pc):
 
 
 def main():
-    fethri = get_available_characters()['fethri']['create'](3)
-    generate_character_sheet(fethri)
+    pc = get_available_characters()['tamiphi']['create'](3)
+    generate_character_sheet(pc)
 
 
 if __name__ == '__main__':

--- a/ddddd/sheet/sheet_generator.py
+++ b/ddddd/sheet/sheet_generator.py
@@ -136,7 +136,8 @@ def generate_character_sheet(pc):
             add_feature_subsection('Feats', pc.feats, doc)
         add_feature_subsection('Class Features', pc.vocation_features, doc)
 
-    add_spellcasting_page(pc, doc)
+    if pc.spellcasting:
+        add_spellcasting_page(pc, doc)
     add_equipment_page(pc, doc)
 
     doc.generate_pdf(clean_tex=False)
@@ -211,7 +212,7 @@ def add_equipment_page(pc, doc):
 
 
 def main():
-    pc = get_available_characters()['tamiphi']['create'](3)
+    pc = get_available_characters()['fethri']['create'](3)
     generate_character_sheet(pc)
 
 

--- a/ddddd/sheet/sheet_generator.py
+++ b/ddddd/sheet/sheet_generator.py
@@ -1,4 +1,4 @@
-from pylatex import Document, Section, Subsection, Command, LineBreak, LongTable
+from pylatex import Document, Section, Subsection, Command, LineBreak, LongTable, Itemize
 from pylatex.utils import italic, NoEscape, bold
 
 from ddddd.entity import base
@@ -6,6 +6,7 @@ from ddddd.pc_playground import get_available_characters
 
 
 def generate_file_friendly_name(name):
+    """Translates a filename to a more terminal-friendly filename."""
     return name.lower().replace(' ', '_')
 
 
@@ -17,7 +18,7 @@ def generate_character_sheet(pc):
     doc.append(NoEscape(r'\maketitle'))
 
     with doc.create(Section('Basics', numbering=False)):
-        doc.append(bold('Class & Level'))
+        doc.append(bold('Class and Level'))
         doc.append(' {} {}'.format(pc.vocation_name, pc.level))
         doc.append(LineBreak())
 
@@ -54,12 +55,12 @@ def generate_character_sheet(pc):
             data_table.add_hline()
             data_table.end_table_header()
             for ability in pc.ability_scores.keys():
-                ability_row = [
+                weapon_row = [
                     ability,
                     pc.ability_scores[ability].score,
                     base.prettify_modifier(pc.ability_scores[ability].modifier),
                 ]
-                data_table.add_row(ability_row)
+                data_table.add_row(weapon_row)
 
         for ability in pc.ability_scores.keys():
             with doc.create(Subsection('Ability Proficiencies: {}'.format(ability), numbering=False)):
@@ -87,12 +88,117 @@ def generate_character_sheet(pc):
                             ]
                             data_table.add_row(skill_row)
 
+    with doc.create(Section('Health Stuff', numbering=False)):
+        doc.append(bold('Hit Points'))
+        doc.append(' {} / {}'.format(pc.max_hit_points, pc.max_hit_points))
+        doc.append(LineBreak())
+
+        doc.append(bold('Temporary Hit Points'))
+        doc.append(' {}'.format(0))
+        doc.append(LineBreak())
+
+        doc.append(bold('Total Hit Dice'))
+        doc.append(' {}'.format(pc.total_hit_dice_prettified))
+        doc.append(LineBreak())
+
+        doc.append(bold('Death Saves'))
+        doc.append(' To be formatted later once I learn how to make proper LaTeX documents.')
+        doc.append(LineBreak())
+
+    with doc.create(Section('Attacks and Spellcasting', numbering=False)):
+        with doc.create(Subsection('Attacks', numbering=False)):
+            with doc.create(LongTable("l l l")) as data_table:
+                data_table.add_hline()
+                data_table.add_row(['Name', 'Attack Bonus', 'Damage'])
+                data_table.add_hline()
+                data_table.end_table_header()
+
+                for weapon in pc.worn_items.weapons:
+                    weapon_details = pc.calculate_weapon_bonuses()[weapon.name]
+                    attack_bonus = '{} ({})'.format(base.prettify_modifier(weapon_details['attack_bonus']),
+                                                    weapon_details['attack_type'])
+                    weapon_row = [
+                        weapon.name,
+                        attack_bonus,
+                        weapon_details['damage'],
+                    ]
+                    data_table.add_row(weapon_row)
+
+                if pc.spellcasting and pc.cantrips:
+                    for cantrip_name in pc.calculate_damage_cantrips():
+                        cantrip_details = pc.calculate_damage_cantrips()[cantrip_name]
+
+                        cantrip_row = [
+                            cantrip_details.name,
+                            cantrip_details['attack_bonus'],
+                            cantrip_details['damage'],
+                        ]
+                        data_table.add_row(cantrip_row)
+
+        # TODO add section for spellcasting, too lazy right now
+
+    with doc.create(Section('Proficiencies', numbering=False)):
+        with doc.create(Subsection('Languages', numbering=False)):
+            with doc.create(Itemize()) as itemize:
+                for p in pc.languages:
+                    itemize.add_item(p)
+        for prof in pc.proficiencies:
+            with doc.create(Subsection(prof, numbering=False)):
+                with doc.create(Itemize()) as itemize:
+                    for p in pc.proficiencies[prof]:
+                        itemize.add_item(p)
+
+    with doc.create(Section('Traits and Features', numbering=False)):
+        def add_feature_subsection(title, features, doc):
+            with doc.create(Subsection(title, numbering=False)):
+                with doc.create(Itemize()) as itemize:
+                    for feature in features:
+                        itemize.add_item(feature.name)
+                        itemize.add_item(feature.description)
+
+        add_feature_subsection('Racial Traits', pc.racial_traits, doc)
+        add_feature_subsection('Background Features', pc.background_feature, doc)
+        if pc.feats:
+            add_feature_subsection('Feats', pc.feats, doc)
+        add_feature_subsection('Class Features', pc.vocation_features, doc)
+
+    with doc.create(Section('Equipment', numbering=False)):
+        doc.append(bold('Carrying Capacity'))
+        doc.append(' {} / {}'.format(pc.carrying_weight, pc.carrying_capacity))
+        doc.append(LineBreak())
+
+        with doc.create(Subsection('Equipped Items', numbering=False)):
+            doc.append(bold('Total Worth:'))
+            doc.append(' {}GP'.format(pc.total_equipment_worth))
+            doc.append(LineBreak())
+
+            if pc.worn_items.armor:
+                doc.append(bold('Armor:'))
+                doc.append(' {} (armor)'.format(pc.worn_items.armor.name))
+                doc.append(LineBreak())
+
+            with doc.create(Itemize()) as itemize:
+                for weapon in pc.worn_items.weapons:
+                    itemize.add_item('{} (weapon)'.format(weapon.name))
+
+        with doc.create(Subsection('Backpack', numbering=False)):
+            doc.append(bold('Total Worth:'))
+            doc.append(' {}GP'.format(pc.total_backpack_worth))
+            doc.append(LineBreak())
+
+            with doc.create(Itemize()) as itemize:
+                for item in pc.backpack.items:
+                    if item.quantity > 1:
+                        itemize.add_item('{} ({})'.format(item.name, item.quantity))
+                    else:
+                        itemize.add_item(item.name)
+
     doc.generate_pdf(clean_tex=False)
     doc.generate_tex()
 
 
 def main():
-    fethri = get_available_characters()['fethri']['create']()
+    fethri = get_available_characters()['fethri']['create'](3)
     generate_character_sheet(fethri)
 
 


### PR DESCRIPTION
Since I prefer to play D&D using old-fashioned paper and pencil, I want to be able to generate a PDF with my character's stats. This should take the PC Python model and translate it into a LaTeX-generated PDF that can be used during gameplay.

I'm not sure if I'll be able to format the PDF into a D&D-style like in https://github.com/rpgtex/DND-5e-LaTeX-Template. I may put that as a separate GitHub issue.

Ref: Issue #30 